### PR TITLE
feat: add annotations to service

### DIFF
--- a/charts/surrealdb/Chart.yaml
+++ b/charts/surrealdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: surrealdb
 type: application
-version: 0.3.0
+version: 0.3.1
 appVersion: 1.0.0
 description: SurrealDB is the ultimate cloud database for tomorrow's applications.
 keywords:

--- a/charts/surrealdb/templates/service.yaml
+++ b/charts/surrealdb/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "surrealdb.fullname" . }}
   labels:
     {{- include "surrealdb.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:


### PR DESCRIPTION
Adds functionality to add annotations to the values yaml. Service annotations are used for GCP NEGs used within custom load balancers.

Use-Case Examples:
- [GCP](https://cloud.google.com/kubernetes-engine/docs/how-to/standalone-neg#create_a_service)
- [AWS](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/service/annotations/)