### PR TITLE
Add SURREAL_OBJECT env variables to deployment

### DIFF
--- a/charts/surrealdb/Chart.yaml
+++ b/charts/surrealdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: surrealdb
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: 1.0.0
 description: SurrealDB is the ultimate cloud database for tomorrow's applications.
 keywords:

--- a/charts/surrealdb/templates/deployment.yaml
+++ b/charts/surrealdb/templates/deployment.yaml
@@ -58,6 +58,12 @@ spec:
             {{- end }}
             - name: SURREAL_AUTH
               value: "{{ .Values.surrealdb.auth }}"
+            {{- range $key, $value := .Values.surrealdb.env }}
+            {{- if regexMatch "^SURREAL_OBJECT_" $key}}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.surrealdb.port }}

--- a/charts/surrealdb/values.yaml
+++ b/charts/surrealdb/values.yaml
@@ -31,6 +31,11 @@ surrealdb:
   # initial_user: ""
   # initial_pass: ""
   port: 8000
+  # Add additional object variables to deployment
+  env:
+    # Enable the following for jwks feature
+    SURREAL_OBJECT_CACHE: "file:/data/cache"
+    SURREAL_OBJECT_STORE: "file:/data/store"
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
JWKs feature in v1.2.1+ requires SURREAL_OBJECT_CACHE and SURREAL_OBJECT_STORE to be defined on the deployment.

Environment Variables are described in:

- [Issue 3528](https://github.com/surrealdb/surrealdb/issues/3528#issuecomment-1963763713)
- [Surreal Code](https://github.com/surrealdb/surrealdb/blob/main/core/src/obs/mod.rs)