### PR TITLE
feat: support custom envs for pods

### DIFF
--- a/charts/surrealdb/README.md
+++ b/charts/surrealdb/README.md
@@ -33,6 +33,7 @@ Read the Kubernetes Deployment guides in https://surrealdb.com/docs/deployment
 | args | list | `["start"]` | Command line arguments to pass to SurrealDB |
 | nodeSelector | object | `{}` | [Node selector] |
 | podAnnotations | object | `{}` | Annotations to be added to SurrealDB pods |
+| podEnvs | list | `[]` | Extra env entries added to the SurrealDB pods |
 | podSecurityContext | object | `{}` (See [values.yaml]) | Toggle and define pod-level security context. |
 | replicaCount | int | `1` | The number of SurrealDB pods to run |
 | resources | object | `{}` | Resource limits and requests |

--- a/charts/surrealdb/templates/deployment.yaml
+++ b/charts/surrealdb/templates/deployment.yaml
@@ -66,6 +66,9 @@ spec:
             - name: SURREAL_OBJECT_STORE
               value: {{ . }}
             {{- end }}
+          {{- with .Values.podEnvs | uniq }}
+              {{- toYaml . | nindent 12}}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.surrealdb.port }}

--- a/charts/surrealdb/values.yaml
+++ b/charts/surrealdb/values.yaml
@@ -56,6 +56,17 @@ serviceAccount:
   # @default -- `""` (defaults to the fullname template)
   name: ""
 
+# -- Extra env entries added to the SurrealDB pods
+podEnvs:
+  []
+  # - name: TZ
+  #   value: "Europe/London"
+  # - name: SURREAL_PASS
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: creds
+  #       key: password
+
 # -- Annotations to be added to SurrealDB pods
 podAnnotations: {}
 


### PR DESCRIPTION
# About
This PR adds support to set custom envs to the deployed pod.

# Why
Users may want to set extra envs for proxy setups, logging or other.  
A special usecass is to supply credentials, such as the initial password in other ways then setting plain text credentials in the values file.  
This allows users to reference existing secrets or configmaps.

