### PR TITLE
Bump Kubernetes versions for kubeval testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,9 +80,10 @@ jobs:
       matrix:
         k8s:
           # from https://github.com/yannh/kubernetes-json-schema
-          - v1.27.6
-          - v1.28.3
-          - v1.29.2
+          - v1.31.12
+          - v1.32.8
+          - v1.33.4
+          - v1.34.0
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
<!--
Thank you very much for your contribution!

Please check the following before submitting this pull request:

- [ ] I have set up a local Kubernetes cluster
- [ ] I have updated test snapshots when bumping chart version (i.e. ran `make update-test-snapshots`)
- [ ] I have added test snapshots to test new values.yaml options (See ./tests/surrealdb_test.go)
- [ ] I have run `make lint test` locally and it's passing
-->

Something I noticed while reviewing CI.