### PR TITLE
Bump kindest node versions to latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - .github/workflows/ci.yaml
       - "charts/**"
       - "e2e/**"
       - "tests/**"
@@ -179,9 +180,10 @@ jobs:
       matrix:
         k8s:
           # from https://hub.docker.com/r/kindest/node/tags
-          - v1.27.3 # renovate: kindest
-          - v1.28.0 # renovate: kindest
-          - v1.29.2 # renovate: kindest
+          - v1.31.12 # renovate: kindest
+          - v1.32.8 # renovate: kindest
+          - v1.33.4 # renovate: kindest
+          - v1.34.0 # renovate: kindest
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
<!--
Thank you very much for your contribution!

Please check the following before submitting this pull request:

- [ ] I have set up a local Kubernetes cluster
- [ ] I have updated test snapshots when bumping chart version (i.e. ran `make update-test-snapshots`)
- [ ] I have added test snapshots to test new values.yaml options (See ./tests/surrealdb_test.go)
- [ ] I have run `make lint test` locally and it's passing
-->

Similar to #28, but for `kind` nodes' k8s versions.
