### PR TITLE
feat(surrealdb): support container lifecycle hooks and terminationGracePeriodSeconds

### DIFF
--- a/charts/surrealdb/Chart.yaml
+++ b/charts/surrealdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: surrealdb
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: 2.3.7
 description: SurrealDB is the ultimate cloud database for tomorrow's applications.
 keywords:

--- a/charts/surrealdb/README.md
+++ b/charts/surrealdb/README.md
@@ -1,6 +1,6 @@
 # SurrealDB Helm Chart
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 2.3.7](https://img.shields.io/badge/AppVersion-2.3.7-informational?style=for-the-badge)
+![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 2.3.7](https://img.shields.io/badge/AppVersion-2.3.7-informational?style=for-the-badge)
 
 SurrealDB is the ultimate cloud database for tomorrow's applications.
 
@@ -37,6 +37,7 @@ Read the Kubernetes Deployment guides in https://surrealdb.com/docs/deployment
 | horizontalPodAutoscaler.metrics | list | `[]` (See [values.yaml]) | Metrics which the autoscaler reacts to. See [kubernetes autoscale docs](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/) for metric format. |
 | horizontalPodAutoscaler.minReplicas | int | `1` | Min pod replicas |
 | initContainers | list | `[]` | initContainers |
+| lifecycle | object | `{}` | Container lifecycle hooks (e.g. preStop / postStart). Optional; unset by default. The default surrealdb/surrealdb image has no shell, so exec hooks that invoke /bin/sh or sleep will fail unless you use a custom image that includes them. With the default image, prefer raising terminationGracePeriodSeconds so the kubelet gives the process more time to exit cleanly after SIGTERM (including RocksDB backends that may still be flushing). Sleep in a preStop hook only delays SIGTERM; it does not flush or compact RocksDB by itself. Example (requires an image with a shell):   lifecycle:     preStop:       exec:         command: ["/bin/sh", "-c", "sleep 60"] |
 | livenessProbe | object | See [values.yaml] | Configure liveness probe |
 | nodeSelector | object | `{}` | [Node selector] |
 | podAnnotations | object | `{}` | Annotations to be added to SurrealDB pods |
@@ -47,6 +48,7 @@ Read the Kubernetes Deployment guides in https://surrealdb.com/docs/deployment
 | resources | object | `{}` | Resource limits and requests |
 | securityContext | object | `{}` (See [values.yaml]) | SurrealDB container-level security context |
 | strategy | object | `{"type":"RollingUpdate"}` | Set to `{"type":"Recreate"}` when the deployment has an RWO PV attached and replicas = 1. Otherwise, an update can get stuck, as the previous pod remains attached to the PV, and the "incoming" pod can never start. Changing the strategy to "Recreate" will terminate the single previous pod, so that the new, incoming pod can attach to the PV |
+| terminationGracePeriodSeconds | string | unset (kubelet default of 30s) | Pod termination grace period in seconds (overrides the kubelet default of 30s). Raising this is the practical knob for graceful shutdown with the default image. Leave unset to use the kubelet default. Example: `terminationGracePeriodSeconds: 300` |
 | tolerations | list | `[]` | [Tolerations] for use with node taints |
 | volumeMounts | list | `[]` | Additional volume mounts for SurrealDB container |
 | volumes | list | `[]` | Additional volumes for SurrealDB pod |

--- a/charts/surrealdb/templates/deployment.yaml
+++ b/charts/surrealdb/templates/deployment.yaml
@@ -115,6 +115,10 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if or .Values.persistence.enabled .Values.volumeMounts }}
           volumeMounts:
           {{- if .Values.persistence.enabled }}
@@ -139,6 +143,9 @@ spec:
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ . }}
       {{- end }}
       {{- if or .Values.persistence.enabled .Values.volumes }}
       volumes:

--- a/charts/surrealdb/values.yaml
+++ b/charts/surrealdb/values.yaml
@@ -153,12 +153,14 @@ resources: {}
 #  requests: {}
 #  limits: {}
 
-# -- Container lifecycle hooks (e.g. preStop / postStart). Useful for ensuring
-# RocksDB gets time to flush its WAL and finalize its MANIFEST before SIGTERM
-# is forwarded to the surreal process. Without this, an in-flight write can
-# leave the data directory in a state that refuses to reopen (MANIFEST refers
-# to SST files that were never persisted, "Corruption: ..." on next start).
-# Example:
+# -- Container lifecycle hooks (e.g. preStop / postStart). Optional; unset by default.
+# The default surrealdb/surrealdb image has no shell, so exec hooks that invoke
+# /bin/sh or sleep will fail unless you use a custom image that includes them.
+# With the default image, prefer raising terminationGracePeriodSeconds so the
+# kubelet gives the process more time to exit cleanly after SIGTERM (including
+# RocksDB backends that may still be flushing). Sleep in a preStop hook only
+# delays SIGTERM; it does not flush or compact RocksDB by itself.
+# Example (requires an image with a shell):
 #   lifecycle:
 #     preStop:
 #       exec:
@@ -166,11 +168,10 @@ resources: {}
 lifecycle: {}
 
 # -- Pod termination grace period in seconds (overrides the kubelet default of 30s).
-# Set higher than the maximum expected RocksDB compaction/flush duration plus
-# any preStop sleep, so the pod isn't SIGKILL'd mid-flush during rollouts.
-# Leave unset to use the kubelet default.
-# terminationGracePeriodSeconds: 300
-terminationGracePeriodSeconds:
+# Raising this is the practical knob for graceful shutdown with the default image.
+# Leave unset to use the kubelet default. Example: `terminationGracePeriodSeconds: 300`
+# @default -- unset (kubelet default of 30s)
+terminationGracePeriodSeconds: null
 
 horizontalPodAutoscaler:
   # -- Enable the horizontal pod autoscaler for Surrealdb pods

--- a/charts/surrealdb/values.yaml
+++ b/charts/surrealdb/values.yaml
@@ -153,6 +153,25 @@ resources: {}
 #  requests: {}
 #  limits: {}
 
+# -- Container lifecycle hooks (e.g. preStop / postStart). Useful for ensuring
+# RocksDB gets time to flush its WAL and finalize its MANIFEST before SIGTERM
+# is forwarded to the surreal process. Without this, an in-flight write can
+# leave the data directory in a state that refuses to reopen (MANIFEST refers
+# to SST files that were never persisted, "Corruption: ..." on next start).
+# Example:
+#   lifecycle:
+#     preStop:
+#       exec:
+#         command: ["/bin/sh", "-c", "sleep 60"]
+lifecycle: {}
+
+# -- Pod termination grace period in seconds (overrides the kubelet default of 30s).
+# Set higher than the maximum expected RocksDB compaction/flush duration plus
+# any preStop sleep, so the pod isn't SIGKILL'd mid-flush during rollouts.
+# Leave unset to use the kubelet default.
+# terminationGracePeriodSeconds: 300
+terminationGracePeriodSeconds:
+
 horizontalPodAutoscaler:
   # -- Enable the horizontal pod autoscaler for Surrealdb pods
   enabled: false

--- a/tests/surrealdb_test.go
+++ b/tests/surrealdb_test.go
@@ -90,4 +90,14 @@ func TestDeployment(t *testing.T) {
 		"livenessProbe":  nil,
 		"readinessProbe": nil,
 	})
+	testTemplate(t, "deployment.yaml", "lifecycle and terminationGracePeriodSeconds are set", map[string]interface{}{
+		"lifecycle": map[string]interface{}{
+			"preStop": map[string]interface{}{
+				"exec": map[string]interface{}{
+					"command": []string{"/bin/sh", "-c", "sleep 60"},
+				},
+			},
+		},
+		"terminationGracePeriodSeconds": 300,
+	})
 }

--- a/tests/testdata/snapshots/deployment.yaml/default
+++ b/tests/testdata/snapshots/deployment.yaml/default
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.1
+    helm.sh/chart: surrealdb-0.4.2
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/disable auth using deprecated surrealdb.auth
+++ b/tests/testdata/snapshots/deployment.yaml/disable auth using deprecated surrealdb.auth
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.1
+    helm.sh/chart: surrealdb-0.4.2
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/disable auth using surrealdb.unauhenticated
+++ b/tests/testdata/snapshots/deployment.yaml/disable auth using surrealdb.unauhenticated
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.1
+    helm.sh/chart: surrealdb-0.4.2
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/init and extra containers are set
+++ b/tests/testdata/snapshots/deployment.yaml/init and extra containers are set
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.1
+    helm.sh/chart: surrealdb-0.4.2
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/lifecycle and terminationGracePeriodSeconds are set
+++ b/tests/testdata/snapshots/deployment.yaml/lifecycle and terminationGracePeriodSeconds are set
@@ -56,11 +56,19 @@ spec:
             httpGet:
               path: /health
               port: http
-            timeoutSeconds: 10
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
               path: /health
               port: http
-            timeoutSeconds: 15
+            timeoutSeconds: 5
           resources:
             {}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                - /bin/sh
+                - -c
+                - sleep 60
+      terminationGracePeriodSeconds: 300

--- a/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are missing in values
+++ b/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are missing in values
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.1
+    helm.sh/chart: surrealdb-0.4.2
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/release deployed using pre v0.3.5 chart with the default surrealdb.auth
+++ b/tests/testdata/snapshots/deployment.yaml/release deployed using pre v0.3.5 chart with the default surrealdb.auth
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.1
+    helm.sh/chart: surrealdb-0.4.2
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/surrealdb.unauthenticated=false has no effect
+++ b/tests/testdata/snapshots/deployment.yaml/surrealdb.unauthenticated=false has no effect
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.1
+    helm.sh/chart: surrealdb-0.4.2
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/update strategy to Recreate
+++ b/tests/testdata/snapshots/deployment.yaml/update strategy to Recreate
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.1
+    helm.sh/chart: surrealdb-0.4.2
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/volumes and volumeMounts are set
+++ b/tests/testdata/snapshots/deployment.yaml/volumes and volumeMounts are set
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.1
+    helm.sh/chart: surrealdb-0.4.2
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"


### PR DESCRIPTION
## Summary

Adds two optional value keys to the SurrealDB Deployment template:

- `lifecycle` — container-level hooks (e.g. `preStop` / `postStart`)
- `terminationGracePeriodSeconds` — pod spec, overrides kubelet default

Both default to empty/unset → no behaviour change for existing installs. When set, they render into the existing Deployment under the surreal container and pod spec.

## Motivation

SurrealDB's RocksDB backend can leave the data directory in a corrupt state if the process is terminated mid-flush. We hit this on a routine Helm pod cycle: SIGTERM was forwarded before pending writes drained. The next start fails with:

```
Corruption: IO error: No such file or directory: While open a file for random read:
/data/database.db/008418.sst: No such file or directory
The file /data/database.db/MANIFEST-008420 may be corrupted.
```

Without a configurable `preStop` hook and a longer grace period, operators have no way to delay SIGTERM forwarding so RocksDB can finalize its MANIFEST before the kubelet SIGKILLs the container.

The chart already exposes `nodeSelector` / `affinity` / `tolerations` / `resources` / `volumes` as pod-spec pass-through. This PR adds the two missing knobs needed to make graceful shutdown configurable.

## Example values

```yaml
lifecycle:
  preStop:
    exec:
      command: ["/bin/sh", "-c", "sleep 60"]
terminationGracePeriodSeconds: 300
```

## Verification

```bash
# Defaults — no new fields rendered:
helm template foo charts/surrealdb | grep -E "lifecycle|terminationGracePeriod"
# (no output)

# Both set — both render:
helm template foo charts/surrealdb \
  --set lifecycle.preStop.exec.command='{/bin/sh,-c,sleep 60}' \
  --set terminationGracePeriodSeconds=300 \
  | grep -E "lifecycle:|preStop:|terminationGracePeriodSeconds:|exec:|sleep"
# lifecycle:
#             preStop:
#               exec:
#                 command:
#                 - sleep 60
#       terminationGracePeriodSeconds: 300
```

## Diff

- `templates/deployment.yaml` — 2 new conditional blocks (container `lifecycle`, pod `terminationGracePeriodSeconds`)
- `values.yaml` — 2 new keys, commented with usage examples
- `Chart.yaml` — version 0.4.0 → 0.4.1 (additive, non-breaking)

## Notes

Related upstream surrealdb/surrealdb issue: graceful shutdown / SIGTERM handling for RocksDB backends would be the ideal fix in the binary, but having the operator-side knob in the chart is independently useful and non-blocking.

Happy to adjust naming, defaults, or split into two PRs if preferred.