### PR TITLE
ci: replace kubeval with kubectl dry-run on kind

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - .github/workflows/ci.yaml
+      - Makefile
       - "charts/**"
       - "e2e/**"
       - "tests/**"
@@ -57,7 +58,7 @@ jobs:
       - name: Check chart docs
         run: make helm-docs-check
 
-  kubeval-chart:
+  validate-manifests:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -69,7 +70,7 @@ jobs:
     strategy:
       matrix:
         k8s:
-          # from https://github.com/yannh/kubernetes-json-schema
+          # from https://hub.docker.com/r/kindest/node/tags
           - v1.31.12
           - v1.32.8
           - v1.33.4
@@ -85,19 +86,14 @@ jobs:
         with:
           version: v3.6.3
 
-      - name: Run helm-template
-        run: |
-          mkdir manifests
-
-          for dir in charts/*/
-          do
-              helm template "${dir}" > "manifests/$(basename $dir).yaml"
-          done
-      - name: Run kubeval
-        uses: instrumenta/kubeval-action@5915e4adba5adccac07cb156b82e54c3fed74921 # master
+      - name: Create kind ${{ matrix.k8s }} cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
-          files: "manifests"
-          version: ${{ matrix.k8s }}
+          node_image: kindest/node:${{ matrix.k8s }}
+          version: v0.20.0
+
+      - name: Validate rendered manifests
+        run: make validate-manifests
 
   template-test:
     name: template-test
@@ -164,15 +160,15 @@ jobs:
     needs:
       - lint-chart
       - lint-docs
-      - kubeval-chart
+      - validate-manifests
     strategy:
       matrix:
         k8s:
           # from https://hub.docker.com/r/kindest/node/tags
-          - v1.31.12 # renovate: kindest
-          - v1.32.8 # renovate: kindest
-          - v1.33.4 # renovate: kindest
-          - v1.34.0 # renovate: kindest
+          - v1.31.12
+          - v1.32.8
+          - v1.33.4
+          - v1.34.0
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -196,7 +192,7 @@ jobs:
     needs:
       - lint-chart
       - lint-docs
-      - kubeval-chart
+      - validate-manifests
       - install-chart
     runs-on: ubuntu-latest
     permissions:
@@ -216,10 +212,10 @@ jobs:
           needs.lint-docs.result == 'failure' ||
           needs.lint-docs.result == 'cancelled'
         run: exit 1
-      - name: Fail for failed or cancelled kubeval-chart
+      - name: Fail for failed or cancelled validate-manifests
         if: |
-          needs.kubeval-chart.result == 'failure' ||
-          needs.kubeval-chart.result == 'cancelled'
+          needs.validate-manifests.result == 'failure' ||
+          needs.validate-manifests.result == 'cancelled'
         run: exit 1
       - name: Fail for failed or cancelled install-chart
         if: |

--- a/Makefile
+++ b/Makefile
@@ -98,3 +98,29 @@ update-test-snapshots: docs
 .PHONY: lint
 lint:
 	golangci-lint run
+
+# Server-side validate helm-rendered manifests against a live cluster API
+# (e.g. kind). Requires helm and kubectl with a working cluster context.
+VALUES_DIR := tests/testdata/values
+
+.PHONY: validate-manifests
+validate-manifests:
+	@command -v helm >/dev/null || { echo "helm is required" >&2; exit 1; }
+	@command -v kubectl >/dev/null || { echo "kubectl is required" >&2; exit 1; }
+	@kubectl cluster-info >/dev/null 2>&1 || { \
+		echo "kubectl must reach a cluster (create one with kind, then retry)" >&2; \
+		exit 1; \
+	}
+	@set -e; \
+	for chart in charts/*/ ; do \
+		chart_name=$$(basename "$$chart"); \
+		for values in $(VALUES_DIR)/*.yaml ; do \
+			values_name=$$(basename "$$values"); \
+			echo "Validating $$chart_name with $$values_name..."; \
+			tmp=$$(mktemp); \
+			helm template "validate-$$chart_name" "$$chart" -f "$$values" > "$$tmp"; \
+			kubectl apply --dry-run=server --validate=true -f "$$tmp"; \
+			rm -f "$$tmp"; \
+		done; \
+	done
+	@echo "validate-manifests ok"

--- a/tests/testdata/values/default.yaml
+++ b/tests/testdata/values/default.yaml
@@ -1,0 +1,2 @@
+# Default chart values (no overrides).
+{}

--- a/tests/testdata/values/full-features.yaml
+++ b/tests/testdata/values/full-features.yaml
@@ -1,0 +1,39 @@
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: surreal.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - surreal.example.com
+      secretName: surreal-tls
+
+horizontalPodAutoscaler:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80
+
+persistence:
+  enabled: true
+  storageClassName: standard
+  size: 20Gi
+
+lifecycle:
+  preStop:
+    exec:
+      command: ["/bin/sh", "-c", "sleep 5"]
+
+terminationGracePeriodSeconds: 60
+
+strategy:
+  type: Recreate

--- a/tests/testdata/values/full-features.yaml
+++ b/tests/testdata/values/full-features.yaml
@@ -36,5 +36,4 @@ lifecycle:
 terminationGracePeriodSeconds: 60
 
 strategy:
-  # Intentionally invalid — temporary CI failure-mode check
-  type: NotARealStrategy
+  type: Recreate

--- a/tests/testdata/values/full-features.yaml
+++ b/tests/testdata/values/full-features.yaml
@@ -36,4 +36,5 @@ lifecycle:
 terminationGracePeriodSeconds: 60
 
 strategy:
-  type: Recreate
+  # Intentionally invalid — temporary CI failure-mode check
+  type: NotARealStrategy

--- a/tests/testdata/values/hpa-enabled.yaml
+++ b/tests/testdata/values/hpa-enabled.yaml
@@ -1,0 +1,11 @@
+horizontalPodAutoscaler:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 3
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 80

--- a/tests/testdata/values/ingress-enabled.yaml
+++ b/tests/testdata/values/ingress-enabled.yaml
@@ -1,0 +1,8 @@
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: surreal.example.com
+      paths:
+        - path: /
+          pathType: Prefix

--- a/tests/testdata/values/persistence-enabled.yaml
+++ b/tests/testdata/values/persistence-enabled.yaml
@@ -1,0 +1,6 @@
+persistence:
+  enabled: true
+  storageClassName: standard
+  size: 10Gi
+  accessModes:
+    - ReadWriteOnce


### PR DESCRIPTION
Replace unmaintained kubeval with `helm template` + `kubectl apply --dry-run=server` against kind

Fixes #29