### PR TITLE
test: persistence coverage on kind

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,9 +146,8 @@ jobs:
           version: v0.20.0
 
       - name: Run e2e test
-        # The timeout is explicitly set to clarify that we intend it to be short enough
-        # and not uncontrollably getting longer.
-        run: go test -v ./e2e/... -timeout 5m
+        # Timeout covers HPA toggles plus persistence PVC bind + pod restart.
+        run: go test -v ./e2e/... -timeout 10m
 
   install-chart:
     name: install-chart

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -146,8 +146,9 @@ jobs:
           version: v0.20.0
 
       - name: Run e2e test
-        # Timeout covers HPA toggles plus persistence PVC bind + pod restart.
-        run: go test -v ./e2e/... -timeout 10m
+        # The timeout is explicitly set to clarify that we intend it to be short enough
+        # and not uncontrollably getting longer.
+        run: go test -v ./e2e/... -timeout 5m
 
   install-chart:
     name: install-chart

--- a/charts/surrealdb/Chart.yaml
+++ b/charts/surrealdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: surrealdb
 type: application
-version: 0.4.4
+version: 0.4.5
 appVersion: 2.3.7
 description: SurrealDB is the ultimate cloud database for tomorrow's applications.
 keywords:

--- a/charts/surrealdb/Chart.yaml
+++ b/charts/surrealdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: surrealdb
 type: application
-version: 0.4.5
+version: 0.4.6
 appVersion: 2.3.7
 description: SurrealDB is the ultimate cloud database for tomorrow's applications.
 keywords:

--- a/charts/surrealdb/README.md
+++ b/charts/surrealdb/README.md
@@ -1,6 +1,6 @@
 # SurrealDB Helm Chart
 
-![Version: 0.4.4](https://img.shields.io/badge/Version-0.4.4-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 2.3.7](https://img.shields.io/badge/AppVersion-2.3.7-informational?style=for-the-badge)
+![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 2.3.7](https://img.shields.io/badge/AppVersion-2.3.7-informational?style=for-the-badge)
 
 SurrealDB is the ultimate cloud database for tomorrow's applications.
 

--- a/charts/surrealdb/README.md
+++ b/charts/surrealdb/README.md
@@ -1,6 +1,6 @@
 # SurrealDB Helm Chart
 
-![Version: 0.4.5](https://img.shields.io/badge/Version-0.4.5-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 2.3.7](https://img.shields.io/badge/AppVersion-2.3.7-informational?style=for-the-badge)
+![Version: 0.4.6](https://img.shields.io/badge/Version-0.4.6-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 2.3.7](https://img.shields.io/badge/AppVersion-2.3.7-informational?style=for-the-badge)
 
 SurrealDB is the ultimate cloud database for tomorrow's applications.
 

--- a/charts/surrealdb/ci/persistence-enabled-values.yaml
+++ b/charts/surrealdb/ci/persistence-enabled-values.yaml
@@ -1,6 +1,12 @@
-# Live install values for chart-testing (ct install).
+# Live install values for chart-testing (ct install / install-chart CI job).
 # Uses the cluster default StorageClass (kind: standard / local-path).
-# fsGroup mitigates PVC permission issues with the nonroot image user (see #31).
+#
+# Official surrealdb/surrealdb runs as USER nonroot (uid/gid 65532):
+#   https://github.com/surrealdb/surrealdb/blob/main/docker/Dockerfile
+# A PVC mounted at /data is often provisioned as root-owned, so without
+# fsGroup the process cannot create the datastore (Permission denied).
+# See https://github.com/surrealdb/helm-charts/issues/31 and
+# https://github.com/surrealdb/surrealdb/issues/6317
 strategy:
   type: Recreate
 persistence:

--- a/charts/surrealdb/ci/persistence-enabled-values.yaml
+++ b/charts/surrealdb/ci/persistence-enabled-values.yaml
@@ -5,8 +5,6 @@
 #   https://github.com/surrealdb/surrealdb/blob/main/docker/Dockerfile
 # A PVC mounted at /data is often provisioned as root-owned, so without
 # fsGroup the process cannot create the datastore (Permission denied).
-# See https://github.com/surrealdb/helm-charts/issues/31 and
-# https://github.com/surrealdb/surrealdb/issues/6317
 strategy:
   type: Recreate
 persistence:

--- a/charts/surrealdb/ci/persistence-enabled-values.yaml
+++ b/charts/surrealdb/ci/persistence-enabled-values.yaml
@@ -1,0 +1,12 @@
+# Live install values for chart-testing (ct install).
+# Uses the cluster default StorageClass (kind: standard / local-path).
+# fsGroup mitigates PVC permission issues with the nonroot image user (see #31).
+strategy:
+  type: Recreate
+persistence:
+  enabled: true
+  size: 1Gi
+surrealdb:
+  path: surrealkv:/data
+podSecurityContext:
+  fsGroup: 65532

--- a/charts/surrealdb/templates/tests/test-connection.yaml
+++ b/charts/surrealdb/templates/tests/test-connection.yaml
@@ -11,4 +11,4 @@ spec:
     - name: test-isready
       image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" $.Chart.AppVersion) }}"
       args: ['isready', '--endpoint', 'http://{{ include "surrealdb.fullname" . }}:{{ .Values.service.port }}']
-  restartPolicy: Never
+  restartPolicy: OnFailure

--- a/charts/surrealdb/values.yaml
+++ b/charts/surrealdb/values.yaml
@@ -113,9 +113,15 @@ podAnnotations: {}
 # @default -- `{}` (See [values.yaml])
 # @section -- General parameters
 podSecurityContext: {}
-#  runAsUser: 999
-#  runAsGroup: 999
-#  fsGroup: 999
+# Official surrealdb/surrealdb images run as USER nonroot (uid/gid 65532):
+#   https://github.com/surrealdb/surrealdb/blob/main/docker/Dockerfile
+# When persistence.enabled mounts a PVC over /data, many CSI/local-path
+# provisioners create the volume as root:root, so the process cannot write
+# (Permission denied). Set fsGroup to the image gid so Kubernetes chowns the
+# volume for the nonroot group. See helm-charts#31 and surrealdb/surrealdb#6317.
+#  fsGroup: 65532
+#  runAsUser: 65532
+#  runAsGroup: 65532
 
 # securityContext -- SurrealDB container-level security context
 # @default -- `{}` (See [values.yaml])
@@ -257,6 +263,14 @@ volumeMounts: []
 
 # Persistence configuration for SurrealDB data
 # persistence --
+# Recommended with persistence.enabled:
+#   strategy.type: Recreate          # RWO + single replica
+#   surrealdb.path: surrealkv:/data  # or rocksdb:/data/...
+#   podSecurityContext.fsGroup: 65532
+# The official image USER is nonroot (65532); see
+# https://github.com/surrealdb/surrealdb/blob/main/docker/Dockerfile
+# Without fsGroup (or an initContainer chown), a root-owned PVC at mountPath
+# often fails with Permission denied (helm-charts#31, surrealdb/surrealdb#6317).
 persistence:
   # persistence.enabled -- Enable persistent storage
   # @section -- Persistence parameters
@@ -282,6 +296,9 @@ persistence:
   # persistence.mountPath -- Mount path for the persistent volume
   # @section -- Persistence parameters
   mountPath: /data
+  # Must match surrealdb.path. Image declares VOLUME /data; PVC replaces image
+  # /data ownership — pair with podSecurityContext.fsGroup: 65532 (see
+  # podSecurityContext comments and Dockerfile link above).
 
 # livenessProbe -- Configure liveness probe
 # @default -- See [values.yaml]

--- a/charts/surrealdb/values.yaml
+++ b/charts/surrealdb/values.yaml
@@ -118,7 +118,7 @@ podSecurityContext: {}
 # When persistence.enabled mounts a PVC over /data, many CSI/local-path
 # provisioners create the volume as root:root, so the process cannot write
 # (Permission denied). Set fsGroup to the image gid so Kubernetes chowns the
-# volume for the nonroot group. See helm-charts#31 and surrealdb/surrealdb#6317.
+# volume for the nonroot group.
 #  fsGroup: 65532
 #  runAsUser: 65532
 #  runAsGroup: 65532
@@ -270,7 +270,7 @@ volumeMounts: []
 # The official image USER is nonroot (65532); see
 # https://github.com/surrealdb/surrealdb/blob/main/docker/Dockerfile
 # Without fsGroup (or an initContainer chown), a root-owned PVC at mountPath
-# often fails with Permission denied (helm-charts#31, surrealdb/surrealdb#6317).
+# often fails with Permission denied.
 persistence:
   # persistence.enabled -- Enable persistent storage
   # @section -- Persistence parameters

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 )
@@ -14,6 +15,7 @@ var (
 	SurrealDBChartPath              = "../charts/surrealdb"
 	KubectlTimeout                  = 1 * time.Second
 	DeploymentReplicasUpdateTimeout = 20 * time.Second
+	DeploymentReadyTimeout          = 3 * time.Minute
 )
 
 func TestMain(m *testing.M) {
@@ -31,6 +33,12 @@ func TestMain(m *testing.M) {
 		DeploymentReplicasUpdateTimeout, err = time.ParseDuration(env)
 		if err != nil {
 			log.Fatalf("failed to parse DEPLOYMENT_REPLICAS_UPDATE_TIMEOUT: %s", err)
+		}
+	}
+	if env := os.Getenv("DEPLOYMENT_READY_TIMEOUT"); env != "" {
+		DeploymentReadyTimeout, err = time.ParseDuration(env)
+		if err != nil {
+			log.Fatalf("failed to parse DEPLOYMENT_READY_TIMEOUT: %s", err)
 		}
 	}
 	os.Exit(m.Run())
@@ -58,7 +66,45 @@ func TestHPAEnableDisable(t *testing.T) {
 	waitUntilDeploymentHasReplicas(t, DeploymentName, 1)
 }
 
+// TestPersistence installs SurrealDB with a PVC, waits for Ready, deletes the pod,
+// and asserts it becomes Ready again on the same claim (kind local-path / default SC).
+func TestPersistence(t *testing.T) {
+	const (
+		ReleaseName    = "sdb-persist"
+		DeploymentName = "sdb-persist-surrealdb"
+		PVCName        = "sdb-persist-surrealdb"
+	)
+
+	assertStorageClassAvailable(t)
+
+	t.Cleanup(func() {
+		helmUninstall(t, ReleaseName)
+	})
+
+	helmUpgrade(t, ReleaseName,
+		"--set", "strategy.type=Recreate",
+		"--set", "persistence.enabled=true",
+		"--set", "persistence.size=1Gi",
+		"--set", "surrealdb.path=surrealkv:/data",
+		"--set", "podSecurityContext.fsGroup=65532",
+	)
+
+	waitUntilDeploymentReady(t, DeploymentName, 1)
+	assertPVCBound(t, PVCName)
+
+	uidBefore := podUIDForDeployment(t, DeploymentName)
+	deletePodsForDeployment(t, DeploymentName)
+	waitUntilDeploymentReady(t, DeploymentName, 1)
+
+	uidAfter := podUIDForDeployment(t, DeploymentName)
+	if uidAfter == "" || uidAfter == uidBefore {
+		t.Fatalf("expected a new pod after delete, before=%q after=%q", uidBefore, uidAfter)
+	}
+	assertPVCBound(t, PVCName)
+}
+
 func helmUpgrade(t *testing.T, release string, args ...string) {
+	t.Helper()
 	c := exec.Command("helm", append([]string{"upgrade", "--install", release, SurrealDBChartPath}, args...)...)
 	res, err := c.CombinedOutput()
 	if err != nil {
@@ -67,14 +113,52 @@ func helmUpgrade(t *testing.T, release string, args ...string) {
 }
 
 type deployment struct {
-	Spec *deploymentSpec `json:"spec"`
+	Spec   *deploymentSpec   `json:"spec"`
+	Status *deploymentStatus `json:"status"`
 }
 
 type deploymentSpec struct {
 	Replicas int `json:"replicas"`
 }
 
+type deploymentStatus struct {
+	ReadyReplicas     int `json:"readyReplicas"`
+	AvailableReplicas int `json:"availableReplicas"`
+}
+
+type storageClassList struct {
+	Items []storageClass `json:"items"`
+}
+
+type storageClass struct {
+	Metadata struct {
+		Name        string            `json:"name"`
+		Annotations map[string]string `json:"annotations"`
+	} `json:"metadata"`
+}
+
+type pvc struct {
+	Status struct {
+		Phase string `json:"phase"`
+	} `json:"status"`
+}
+
+type podList struct {
+	Items []pod `json:"items"`
+}
+
+type pod struct {
+	Metadata struct {
+		Name string `json:"name"`
+		UID  string `json:"uid"`
+	} `json:"metadata"`
+	Status struct {
+		Phase string `json:"phase"`
+	} `json:"status"`
+}
+
 func kubectlGetDeployment(t *testing.T, name string) deployment {
+	t.Helper()
 	ctx, cancel := context.WithTimeout(context.Background(), KubectlTimeout)
 	defer cancel()
 	c := exec.CommandContext(ctx, "kubectl", "get", "deployment", name, "-o", "json")
@@ -93,6 +177,7 @@ func kubectlGetDeployment(t *testing.T, name string) deployment {
 }
 
 func helmUninstall(t *testing.T, release string) {
+	t.Helper()
 	c := exec.Command("helm", "uninstall", release)
 	res, err := c.CombinedOutput()
 	if err != nil {
@@ -101,23 +186,127 @@ func helmUninstall(t *testing.T, release string) {
 }
 
 func waitUntilDeploymentHasReplicas(t *testing.T, name string, replicas int) {
-	done := make(chan struct{})
-	defer close(done)
-	go func() {
-		for {
-			deployment := kubectlGetDeployment(t, name)
-			if deployment.Spec.Replicas == replicas {
-				done <- struct{}{}
-				return
-			}
-			time.Sleep(1 * time.Second)
+	t.Helper()
+	deadline := time.Now().Add(DeploymentReplicasUpdateTimeout)
+	for time.Now().Before(deadline) {
+		deployment := kubectlGetDeployment(t, name)
+		if deployment.Spec != nil && deployment.Spec.Replicas == replicas {
+			return
 		}
-	}()
-
-	select {
-	case <-done:
-		return
-	case <-time.After(DeploymentReplicasUpdateTimeout):
-		t.Fatalf("timed out waiting for deployment to have %d replicas", replicas)
+		time.Sleep(1 * time.Second)
 	}
+	t.Fatalf("timed out waiting for deployment to have %d replicas", replicas)
+}
+
+func waitUntilDeploymentReady(t *testing.T, name string, replicas int) {
+	t.Helper()
+	deadline := time.Now().Add(DeploymentReadyTimeout)
+	var last deployment
+	for time.Now().Before(deadline) {
+		last = kubectlGetDeployment(t, name)
+		if last.Status != nil &&
+			last.Status.ReadyReplicas >= replicas &&
+			last.Status.AvailableReplicas >= replicas {
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	dump := kubectlDebug(t, "get", "pods,pvc,events", "-o", "wide")
+	t.Fatalf("timed out waiting for deployment %s to be ready (%d replicas); last status=%+v\n%s",
+		name, replicas, last.Status, dump)
+}
+
+func assertStorageClassAvailable(t *testing.T) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), KubectlTimeout)
+	defer cancel()
+	c := exec.CommandContext(ctx, "kubectl", "get", "storageclass", "-o", "json")
+	res, err := c.CombinedOutput()
+	if err != nil {
+		t.Fatalf("kubectl get storageclass failed: %s", string(res))
+	}
+
+	var list storageClassList
+	if err := json.Unmarshal(res, &list); err != nil {
+		t.Fatalf("failed to unmarshal storageclasses: %s", err)
+	}
+	if len(list.Items) == 0 {
+		t.Fatal("no StorageClass found; kind provides local-path as 'standard' (or 'local-path') by default — create a kind cluster with default storage before running this test")
+	}
+
+	for _, sc := range list.Items {
+		if sc.Metadata.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
+			t.Logf("using default StorageClass %q", sc.Metadata.Name)
+			return
+		}
+	}
+	for _, sc := range list.Items {
+		if sc.Metadata.Name == "standard" || sc.Metadata.Name == "local-path" {
+			t.Logf("no default StorageClass; found kind-compatible StorageClass %q", sc.Metadata.Name)
+			return
+		}
+	}
+	names := make([]string, 0, len(list.Items))
+	for _, sc := range list.Items {
+		names = append(names, sc.Metadata.Name)
+	}
+	t.Fatalf("no usable StorageClass (want default, standard, or local-path); found: %s", strings.Join(names, ", "))
+}
+
+func assertPVCBound(t *testing.T, name string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), KubectlTimeout)
+	defer cancel()
+	c := exec.CommandContext(ctx, "kubectl", "get", "pvc", name, "-o", "json")
+	res, err := c.CombinedOutput()
+	if err != nil {
+		t.Fatalf("kubectl get pvc failed: %s", string(res))
+	}
+	var claim pvc
+	if err := json.Unmarshal(res, &claim); err != nil {
+		t.Fatalf("failed to unmarshal pvc: %s", err)
+	}
+	if claim.Status.Phase != "Bound" {
+		t.Fatalf("expected PVC %s to be Bound, got %q", name, claim.Status.Phase)
+	}
+}
+
+func deletePodsForDeployment(t *testing.T, deploymentName string) {
+	t.Helper()
+	// DeploymentName is "<release>-surrealdb"; instance label is the release name.
+	release := strings.TrimSuffix(deploymentName, "-surrealdb")
+	c := exec.Command("kubectl", "delete", "pod", "-l", "app.kubernetes.io/instance="+release, "--wait=true")
+	res, err := c.CombinedOutput()
+	if err != nil {
+		t.Fatalf("kubectl delete pod failed: %s", string(res))
+	}
+}
+
+func podUIDForDeployment(t *testing.T, deploymentName string) string {
+	t.Helper()
+	release := strings.TrimSuffix(deploymentName, "-surrealdb")
+	ctx, cancel := context.WithTimeout(context.Background(), KubectlTimeout)
+	defer cancel()
+	c := exec.CommandContext(ctx, "kubectl", "get", "pods", "-l", "app.kubernetes.io/instance="+release, "-o", "json")
+	res, err := c.CombinedOutput()
+	if err != nil {
+		t.Fatalf("kubectl get pods failed: %s", string(res))
+	}
+	var list podList
+	if err := json.Unmarshal(res, &list); err != nil {
+		t.Fatalf("failed to unmarshal pods: %s", err)
+	}
+	if len(list.Items) == 0 {
+		return ""
+	}
+	return list.Items[0].Metadata.UID
+}
+
+func kubectlDebug(t *testing.T, args ...string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	c := exec.CommandContext(ctx, "kubectl", args...)
+	res, _ := c.CombinedOutput()
+	return string(res)
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -68,6 +68,8 @@ func TestHPAEnableDisable(t *testing.T) {
 
 // TestPersistence installs SurrealDB with a PVC, waits for Ready, deletes the pod,
 // and asserts it becomes Ready again on the same claim (kind local-path / default SC).
+// Uses podSecurityContext.fsGroup=65532 because the official image USER is nonroot
+// (https://github.com/surrealdb/surrealdb/blob/main/docker/Dockerfile); see #31.
 func TestPersistence(t *testing.T) {
 	const (
 		ReleaseName    = "sdb-persist"

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -69,7 +69,7 @@ func TestHPAEnableDisable(t *testing.T) {
 // TestPersistence installs SurrealDB with a PVC, waits for Ready, deletes the pod,
 // and asserts it becomes Ready again on the same claim (kind local-path / default SC).
 // Uses podSecurityContext.fsGroup=65532 because the official image USER is nonroot
-// (https://github.com/surrealdb/surrealdb/blob/main/docker/Dockerfile); see #31.
+// (https://github.com/surrealdb/surrealdb/blob/main/docker/Dockerfile).
 func TestPersistence(t *testing.T) {
 	const (
 		ReleaseName    = "sdb-persist"

--- a/tests/testdata/snapshots/deployment.yaml/default
+++ b/tests/testdata/snapshots/deployment.yaml/default
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.5
+    helm.sh/chart: surrealdb-0.4.6
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/default
+++ b/tests/testdata/snapshots/deployment.yaml/default
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.4
+    helm.sh/chart: surrealdb-0.4.5
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/disable auth using deprecated surrealdb.auth
+++ b/tests/testdata/snapshots/deployment.yaml/disable auth using deprecated surrealdb.auth
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.5
+    helm.sh/chart: surrealdb-0.4.6
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/disable auth using deprecated surrealdb.auth
+++ b/tests/testdata/snapshots/deployment.yaml/disable auth using deprecated surrealdb.auth
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.4
+    helm.sh/chart: surrealdb-0.4.5
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/disable auth using surrealdb.unauhenticated
+++ b/tests/testdata/snapshots/deployment.yaml/disable auth using surrealdb.unauhenticated
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.5
+    helm.sh/chart: surrealdb-0.4.6
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/disable auth using surrealdb.unauhenticated
+++ b/tests/testdata/snapshots/deployment.yaml/disable auth using surrealdb.unauhenticated
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.4
+    helm.sh/chart: surrealdb-0.4.5
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/init and extra containers are set
+++ b/tests/testdata/snapshots/deployment.yaml/init and extra containers are set
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.5
+    helm.sh/chart: surrealdb-0.4.6
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/init and extra containers are set
+++ b/tests/testdata/snapshots/deployment.yaml/init and extra containers are set
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.4
+    helm.sh/chart: surrealdb-0.4.5
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/lifecycle and terminationGracePeriodSeconds are set
+++ b/tests/testdata/snapshots/deployment.yaml/lifecycle and terminationGracePeriodSeconds are set
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.5
+    helm.sh/chart: surrealdb-0.4.6
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/lifecycle and terminationGracePeriodSeconds are set
+++ b/tests/testdata/snapshots/deployment.yaml/lifecycle and terminationGracePeriodSeconds are set
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.4
+    helm.sh/chart: surrealdb-0.4.5
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are missing in values
+++ b/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are missing in values
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.5
+    helm.sh/chart: surrealdb-0.4.6
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are missing in values
+++ b/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are missing in values
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.4
+    helm.sh/chart: surrealdb-0.4.5
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are overridden
+++ b/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are overridden
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.5
+    helm.sh/chart: surrealdb-0.4.6
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are overridden
+++ b/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are overridden
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.4
+    helm.sh/chart: surrealdb-0.4.5
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/release deployed using pre v0.3.5 chart with the default surrealdb.auth
+++ b/tests/testdata/snapshots/deployment.yaml/release deployed using pre v0.3.5 chart with the default surrealdb.auth
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.5
+    helm.sh/chart: surrealdb-0.4.6
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/release deployed using pre v0.3.5 chart with the default surrealdb.auth
+++ b/tests/testdata/snapshots/deployment.yaml/release deployed using pre v0.3.5 chart with the default surrealdb.auth
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.4
+    helm.sh/chart: surrealdb-0.4.5
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/surrealdb.unauthenticated=false has no effect
+++ b/tests/testdata/snapshots/deployment.yaml/surrealdb.unauthenticated=false has no effect
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.5
+    helm.sh/chart: surrealdb-0.4.6
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/surrealdb.unauthenticated=false has no effect
+++ b/tests/testdata/snapshots/deployment.yaml/surrealdb.unauthenticated=false has no effect
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.4
+    helm.sh/chart: surrealdb-0.4.5
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/update strategy to Recreate
+++ b/tests/testdata/snapshots/deployment.yaml/update strategy to Recreate
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.5
+    helm.sh/chart: surrealdb-0.4.6
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/update strategy to Recreate
+++ b/tests/testdata/snapshots/deployment.yaml/update strategy to Recreate
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.4
+    helm.sh/chart: surrealdb-0.4.5
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/volumes and volumeMounts are set
+++ b/tests/testdata/snapshots/deployment.yaml/volumes and volumeMounts are set
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.5
+    helm.sh/chart: surrealdb-0.4.6
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/deployment.yaml/volumes and volumeMounts are set
+++ b/tests/testdata/snapshots/deployment.yaml/volumes and volumeMounts are set
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.4
+    helm.sh/chart: surrealdb-0.4.5
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/pvc.yaml/persistence enabled with storageClassName and selector
+++ b/tests/testdata/snapshots/pvc.yaml/persistence enabled with storageClassName and selector
@@ -5,7 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.5
+    helm.sh/chart: surrealdb-0.4.6
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"

--- a/tests/testdata/snapshots/pvc.yaml/persistence enabled with storageClassName and selector
+++ b/tests/testdata/snapshots/pvc.yaml/persistence enabled with storageClassName and selector
@@ -5,7 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.4
+    helm.sh/chart: surrealdb-0.4.5
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.3.7"


### PR DESCRIPTION
Adds end-to-end coverage that deploys SurrealDB with persistent storage on kind and documents how to avoid volume permission issues with the official image.