### PR TITLE
Bump to SurrealDB 2.6.5 with 3.x coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,6 +123,11 @@ jobs:
   e2e-test:
     name: e2e-test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        surrealdb:
+          - v2.6.5
+          - v3.2.0
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -148,6 +153,8 @@ jobs:
       - name: Run e2e test
         # The timeout is explicitly set to clarify that we intend it to be short enough
         # and not uncontrollably getting longer.
+        env:
+          SURREALDB_IMAGE_TAG: ${{ matrix.surrealdb }}
         run: go test -v ./e2e/... -timeout 5m
 
   install-chart:
@@ -194,6 +201,7 @@ jobs:
       - lint-docs
       - validate-manifests
       - install-chart
+      - e2e-test
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -221,4 +229,9 @@ jobs:
         if: |
           needs.install-chart.result == 'failure' ||
           needs.install-chart.result == 'cancelled'
+        run: exit 1
+      - name: Fail for failed or cancelled e2e-test
+        if: |
+          needs.e2e-test.result == 'failure' ||
+          needs.e2e-test.result == 'cancelled'
         run: exit 1

--- a/Makefile
+++ b/Makefile
@@ -85,15 +85,38 @@ build: docs
 clean:
 	$(GO) clean -modcache
 
+# SurrealDB image tags for local e2e (keep in sync with e2e-test matrix in .github/workflows/ci.yaml).
+E2E_SURREALDB_TAGS ?= v2.6.5 v3.2.0
+
+# Full local parity with CI template + e2e jobs: unit/snapshot tests, then each
+# SurrealDB tag as a separate `go test` invocation (avoids go test cache reusing
+# results across SURREALDB_IMAGE_TAG values).
 .PHONY: test
-test: helm-docs-check
+test: helm-docs-check test-unit test-e2e
+
+.PHONY: test-unit
+test-unit:
 	$(GO) clean -testcache
-	$(GO) test -v -cover ./...
+	$(GO) test -v -cover ./tests/...
+
+.PHONY: test-e2e
+test-e2e:
+	@command -v helm >/dev/null || { echo "helm is required for e2e" >&2; exit 1; }
+	@command -v kubectl >/dev/null || { echo "kubectl is required for e2e" >&2; exit 1; }
+	@kubectl cluster-info >/dev/null 2>&1 || { \
+		echo "kubectl must reach a cluster (create one with kind, then retry)" >&2; \
+		exit 1; \
+	}
+	@set -e; \
+	for tag in $(E2E_SURREALDB_TAGS); do \
+		echo "=== e2e SurrealDB $$tag ==="; \
+		SURREALDB_IMAGE_TAG=$$tag $(GO) test -v -count=1 ./e2e/... -timeout 5m; \
+	done
 
 .PHONY: update-test-snapshots
 update-test-snapshots: docs
 	$(GO) clean -testcache
-	UPDATE_SNAPSHOT="deployment.yaml/*" $(GO) test -v -cover ./...
+	UPDATE_SNAPSHOT="deployment.yaml/*" $(GO) test -v -cover ./tests/...
 
 .PHONY: lint
 lint:

--- a/charts/surrealdb/Chart.yaml
+++ b/charts/surrealdb/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: surrealdb
 type: application
 version: 0.5.0
-appVersion: 3.2.0
+appVersion: 2.6.5
 description: SurrealDB is the ultimate cloud database for tomorrow's applications.
 keywords:
   - surrealdb

--- a/charts/surrealdb/Chart.yaml
+++ b/charts/surrealdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: surrealdb
 type: application
-version: 0.4.7
+version: 0.5.0
 appVersion: 2.6.5
 description: SurrealDB is the ultimate cloud database for tomorrow's applications.
 keywords:

--- a/charts/surrealdb/Chart.yaml
+++ b/charts/surrealdb/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: surrealdb
 type: application
-version: 0.5.0
+version: 0.4.7
 appVersion: 2.6.5
 description: SurrealDB is the ultimate cloud database for tomorrow's applications.
 keywords:

--- a/charts/surrealdb/Chart.yaml
+++ b/charts/surrealdb/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: surrealdb
 type: application
-version: 0.4.6
-appVersion: 2.3.7
+version: 0.5.0
+appVersion: 3.2.0
 description: SurrealDB is the ultimate cloud database for tomorrow's applications.
 keywords:
   - surrealdb

--- a/charts/surrealdb/README.md
+++ b/charts/surrealdb/README.md
@@ -1,6 +1,6 @@
 # SurrealDB Helm Chart
 
-![Version: 0.4.7](https://img.shields.io/badge/Version-0.4.7-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 2.6.5](https://img.shields.io/badge/AppVersion-2.6.5-informational?style=for-the-badge)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 2.6.5](https://img.shields.io/badge/AppVersion-2.6.5-informational?style=for-the-badge)
 
 SurrealDB is the ultimate cloud database for tomorrow's applications.
 

--- a/charts/surrealdb/README.md
+++ b/charts/surrealdb/README.md
@@ -1,6 +1,6 @@
 # SurrealDB Helm Chart
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 3.2.0](https://img.shields.io/badge/AppVersion-3.2.0-informational?style=for-the-badge)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 2.6.5](https://img.shields.io/badge/AppVersion-2.6.5-informational?style=for-the-badge)
 
 SurrealDB is the ultimate cloud database for tomorrow's applications.
 
@@ -17,6 +17,10 @@ This chart facilitates the deployment of [SurrealDB](https://surrealdb.com/docs/
 ## Usage
 
 Read the Kubernetes Deployment guides in https://surrealdb.com/docs/deployment
+
+## SurrealDB versions
+
+The chart default `appVersion` tracks the latest SurrealDB **2.x** release. SurrealDB 3.x is supported by setting `image.tag` (for example `v3.2.0`). The 2.x and 3.x on-disk formats are incompatible, so do not upgrade an existing PersistentVolume by only changing the image tag. Follow the official [2.x to 3.x migration guide](https://surrealdb.com/docs/build/migrating/from-old-surrealdb-versions/2x-to-3x).
 
 ## Overrides
 

--- a/charts/surrealdb/README.md
+++ b/charts/surrealdb/README.md
@@ -22,7 +22,7 @@ Read the Kubernetes Deployment guides in https://surrealdb.com/docs/deployment
 
 The chart default `appVersion` tracks the latest SurrealDB **2.x** release. SurrealDB 3.x is supported by setting `image.tag` (for example `v3.2.0`). The 2.x and 3.x on-disk formats are incompatible, so do not upgrade an existing PersistentVolume by only changing the image tag. Follow the official [2.x to 3.x migration guide](https://surrealdb.com/docs/build/migrating/from-old-surrealdb-versions/2x-to-3x).
 
-A chart **minor** version bump means either a new chart feature or a SurrealDB minor bump in `appVersion` (the default image when `image.tag` is empty). Pin `image.tag` if you need the image to stay fixed across chart upgrades.
+A chart **minor** version bump means either a new chart feature or a SurrealDB minor bump in `appVersion` (the default image when `image.tag` is empty). Pinning `image.tag` is highly recommended so chart upgrades do not change the SurrealDB image unexpectedly.
 
 ## Overrides
 

--- a/charts/surrealdb/README.md
+++ b/charts/surrealdb/README.md
@@ -22,6 +22,8 @@ Read the Kubernetes Deployment guides in https://surrealdb.com/docs/deployment
 
 The chart default `appVersion` tracks the latest SurrealDB **2.x** release. SurrealDB 3.x is supported by setting `image.tag` (for example `v3.2.0`). The 2.x and 3.x on-disk formats are incompatible, so do not upgrade an existing PersistentVolume by only changing the image tag. Follow the official [2.x to 3.x migration guide](https://surrealdb.com/docs/build/migrating/from-old-surrealdb-versions/2x-to-3x).
 
+A chart **minor** version bump means either a new chart feature or a SurrealDB minor bump in `appVersion` (the default image when `image.tag` is empty). Pin `image.tag` if you need the image to stay fixed across chart upgrades.
+
 ## Overrides
 
 | Key | Type | Default | Description |

--- a/charts/surrealdb/README.md
+++ b/charts/surrealdb/README.md
@@ -1,6 +1,6 @@
 # SurrealDB Helm Chart
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 2.6.5](https://img.shields.io/badge/AppVersion-2.6.5-informational?style=for-the-badge)
+![Version: 0.4.7](https://img.shields.io/badge/Version-0.4.7-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 2.6.5](https://img.shields.io/badge/AppVersion-2.6.5-informational?style=for-the-badge)
 
 SurrealDB is the ultimate cloud database for tomorrow's applications.
 

--- a/charts/surrealdb/README.md
+++ b/charts/surrealdb/README.md
@@ -1,6 +1,6 @@
 # SurrealDB Helm Chart
 
-![Version: 0.4.6](https://img.shields.io/badge/Version-0.4.6-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 2.3.7](https://img.shields.io/badge/AppVersion-2.3.7-informational?style=for-the-badge)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=for-the-badge) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=for-the-badge) ![AppVersion: 3.2.0](https://img.shields.io/badge/AppVersion-3.2.0-informational?style=for-the-badge)
 
 SurrealDB is the ultimate cloud database for tomorrow's applications.
 

--- a/charts/surrealdb/README.md.gotmpl
+++ b/charts/surrealdb/README.md.gotmpl
@@ -24,6 +24,8 @@ Read the Kubernetes Deployment guides in https://surrealdb.com/docs/deployment
 
 The chart default `appVersion` tracks the latest SurrealDB **2.x** release. SurrealDB 3.x is supported by setting `image.tag` (for example `v3.2.0`). The 2.x and 3.x on-disk formats are incompatible, so do not upgrade an existing PersistentVolume by only changing the image tag. Follow the official [2.x to 3.x migration guide](https://surrealdb.com/docs/build/migrating/from-old-surrealdb-versions/2x-to-3x).
 
+A chart **minor** version bump means either a new chart feature or a SurrealDB minor bump in `appVersion` (the default image when `image.tag` is empty). Pin `image.tag` if you need the image to stay fixed across chart upgrades.
+
 
 ## Overrides
 

--- a/charts/surrealdb/README.md.gotmpl
+++ b/charts/surrealdb/README.md.gotmpl
@@ -20,6 +20,10 @@ This chart facilitates the deployment of [SurrealDB](https://surrealdb.com/docs/
 
 Read the Kubernetes Deployment guides in https://surrealdb.com/docs/deployment
 
+## SurrealDB versions
+
+The chart default `appVersion` tracks the latest SurrealDB **2.x** release. SurrealDB 3.x is supported by setting `image.tag` (for example `v3.2.0`). The 2.x and 3.x on-disk formats are incompatible, so do not upgrade an existing PersistentVolume by only changing the image tag. Follow the official [2.x to 3.x migration guide](https://surrealdb.com/docs/build/migrating/from-old-surrealdb-versions/2x-to-3x).
+
 
 ## Overrides
 

--- a/charts/surrealdb/README.md.gotmpl
+++ b/charts/surrealdb/README.md.gotmpl
@@ -24,7 +24,7 @@ Read the Kubernetes Deployment guides in https://surrealdb.com/docs/deployment
 
 The chart default `appVersion` tracks the latest SurrealDB **2.x** release. SurrealDB 3.x is supported by setting `image.tag` (for example `v3.2.0`). The 2.x and 3.x on-disk formats are incompatible, so do not upgrade an existing PersistentVolume by only changing the image tag. Follow the official [2.x to 3.x migration guide](https://surrealdb.com/docs/build/migrating/from-old-surrealdb-versions/2x-to-3x).
 
-A chart **minor** version bump means either a new chart feature or a SurrealDB minor bump in `appVersion` (the default image when `image.tag` is empty). Pin `image.tag` if you need the image to stay fixed across chart upgrades.
+A chart **minor** version bump means either a new chart feature or a SurrealDB minor bump in `appVersion` (the default image when `image.tag` is empty). Pinning `image.tag` is highly recommended so chart upgrades do not change the SurrealDB image unexpectedly.
 
 
 ## Overrides

--- a/charts/surrealdb/ci/surrealdb-2.6.5-persistence-values.yaml
+++ b/charts/surrealdb/ci/surrealdb-2.6.5-persistence-values.yaml
@@ -1,0 +1,19 @@
+# Live install values for chart-testing (ct install / install-chart CI job).
+# Pins SurrealDB 2.6.x while the chart default appVersion tracks 3.x.
+# Uses the cluster default StorageClass (kind: standard / local-path).
+#
+# Official surrealdb/surrealdb runs as USER nonroot (uid/gid 65532):
+#   https://github.com/surrealdb/surrealdb/blob/main/docker/Dockerfile
+# A PVC mounted at /data is often provisioned as root-owned, so without
+# fsGroup the process cannot create the datastore (Permission denied).
+image:
+  tag: v2.6.5
+strategy:
+  type: Recreate
+persistence:
+  enabled: true
+  size: 1Gi
+surrealdb:
+  path: surrealkv:/data
+podSecurityContext:
+  fsGroup: 65532

--- a/charts/surrealdb/ci/surrealdb-3.2.0-persistence-values.yaml
+++ b/charts/surrealdb/ci/surrealdb-3.2.0-persistence-values.yaml
@@ -1,5 +1,5 @@
 # Live install values for chart-testing (ct install / install-chart CI job).
-# Pins SurrealDB 2.6.x while the chart default appVersion tracks 3.x.
+# Pins SurrealDB 3.x while the chart default appVersion stays on 2.x.
 # Uses the cluster default StorageClass (kind: standard / local-path).
 #
 # Official surrealdb/surrealdb runs as USER nonroot (uid/gid 65532):
@@ -7,7 +7,7 @@
 # A PVC mounted at /data is often provisioned as root-owned, so without
 # fsGroup the process cannot create the datastore (Permission denied).
 image:
-  tag: v2.6.5
+  tag: v3.2.0
 strategy:
   type: Recreate
 persistence:

--- a/charts/surrealdb/values.yaml
+++ b/charts/surrealdb/values.yaml
@@ -20,8 +20,8 @@ image:
   # @section -- Image parameters
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion (currently SurrealDB 2.6.x).
-  # Chart minor bumps mean a new chart feature and/or a SurrealDB minor bump in appVersion; pin
-  # image.tag if you need the image to stay fixed across chart upgrades.
+  # Chart minor bumps mean a new chart feature and/or a SurrealDB minor bump in appVersion.
+  # Pinning image.tag is highly recommended so chart upgrades do not change the image unexpectedly.
   # To run SurrealDB 3.x, set image.tag (e.g. v3.2.0). Do not treat a 2.x → 3.x image bump as an
   # in-place datastore upgrade; follow the official migration guide:
   # https://surrealdb.com/docs/build/migrating/from-old-surrealdb-versions/2x-to-3x

--- a/charts/surrealdb/values.yaml
+++ b/charts/surrealdb/values.yaml
@@ -57,11 +57,11 @@ surrealdb:
   # initial_pass: ""
   # -- Enable unauthenticated access
   # Warning: Enabling it will allow any unauthenticated user to access SurrealDB!
-  # Authentication is enabled by default in 2.x. This value replaces the depreacted "auth" value.
+  # Authentication is enabled by default in SurrealDB 2.x and 3.x. This value replaces the deprecated "auth" value.
   # unauthenticated: false
   # -- DEPRECATED: Enable authentication
-  # This value has been deprecated in 2.x but is kept for backward compatibility.
-  # The "unauthenticated" value should now be used instead, which will be converted in 1.x deployments.
+  # This value has been deprecated since SurrealDB 2.x but is kept for backward compatibility.
+  # Prefer "unauthenticated" instead; the chart still emits both SURREAL_AUTH and SURREAL_UNAUTHENTICATED.
   # auth: true
 
   # surrealdb.port -- SurrealDB container port

--- a/charts/surrealdb/values.yaml
+++ b/charts/surrealdb/values.yaml
@@ -19,7 +19,10 @@ image:
   # image.pullPolicy -- Image pull policy for SurrealDB
   # @section -- Image parameters
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # Overrides the image tag whose default is the chart appVersion (currently SurrealDB 2.6.x).
+  # To run SurrealDB 3.x, set image.tag (e.g. v3.2.0). Do not treat a 2.x → 3.x image bump as an
+  # in-place datastore upgrade; follow the official migration guide:
+  # https://surrealdb.com/docs/build/migrating/from-old-surrealdb-versions/2x-to-3x
   # image.tag -- Tag to use for SurrealDB
   # @default -- `""` (defaults to chart appVersion)
   # @section -- Image parameters

--- a/charts/surrealdb/values.yaml
+++ b/charts/surrealdb/values.yaml
@@ -20,6 +20,8 @@ image:
   # @section -- Image parameters
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion (currently SurrealDB 2.6.x).
+  # Chart minor bumps mean a new chart feature and/or a SurrealDB minor bump in appVersion; pin
+  # image.tag if you need the image to stay fixed across chart upgrades.
   # To run SurrealDB 3.x, set image.tag (e.g. v3.2.0). Do not treat a 2.x → 3.x image bump as an
   # in-place datastore upgrade; follow the official migration guide:
   # https://surrealdb.com/docs/build/migrating/from-old-surrealdb-versions/2x-to-3x

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -24,8 +24,9 @@ func TestMain(m *testing.M) {
 	if env := os.Getenv("SURREALDB_CHART_PATH"); env != "" {
 		SurrealDBChartPath = env
 	}
-	if env := os.Getenv("SURREALDB_IMAGE_TAG"); env != "" {
-		SurrealDBImageTag = env
+	SurrealDBImageTag = os.Getenv("SURREALDB_IMAGE_TAG")
+	if SurrealDBImageTag == "" {
+		log.Fatal("SURREALDB_IMAGE_TAG is required (e.g. v2.6.5 or v3.2.0); refuse to run e2e against an implicit chart default")
 	}
 	if env := os.Getenv("KUBECTL_TIMEOUT"); env != "" {
 		KubectlTimeout, err = time.ParseDuration(env)
@@ -111,11 +112,10 @@ func TestPersistence(t *testing.T) {
 
 func helmUpgrade(t *testing.T, release string, args ...string) {
 	t.Helper()
-	cmdArgs := []string{"upgrade", "--install", release, SurrealDBChartPath}
-	if SurrealDBImageTag != "" {
-		cmdArgs = append(cmdArgs, "--set", "image.tag="+SurrealDBImageTag)
-	}
-	cmdArgs = append(cmdArgs, args...)
+	cmdArgs := append([]string{
+		"upgrade", "--install", release, SurrealDBChartPath,
+		"--set", "image.tag=" + SurrealDBImageTag,
+	}, args...)
 	c := exec.Command("helm", cmdArgs...)
 	res, err := c.CombinedOutput()
 	if err != nil {

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	SurrealDBChartPath              = "../charts/surrealdb"
+	SurrealDBImageTag               = ""
 	KubectlTimeout                  = 1 * time.Second
 	DeploymentReplicasUpdateTimeout = 20 * time.Second
 	DeploymentReadyTimeout          = 3 * time.Minute
@@ -22,6 +23,9 @@ func TestMain(m *testing.M) {
 	var err error
 	if env := os.Getenv("SURREALDB_CHART_PATH"); env != "" {
 		SurrealDBChartPath = env
+	}
+	if env := os.Getenv("SURREALDB_IMAGE_TAG"); env != "" {
+		SurrealDBImageTag = env
 	}
 	if env := os.Getenv("KUBECTL_TIMEOUT"); env != "" {
 		KubectlTimeout, err = time.ParseDuration(env)
@@ -107,7 +111,12 @@ func TestPersistence(t *testing.T) {
 
 func helmUpgrade(t *testing.T, release string, args ...string) {
 	t.Helper()
-	c := exec.Command("helm", append([]string{"upgrade", "--install", release, SurrealDBChartPath}, args...)...)
+	cmdArgs := []string{"upgrade", "--install", release, SurrealDBChartPath}
+	if SurrealDBImageTag != "" {
+		cmdArgs = append(cmdArgs, "--set", "image.tag="+SurrealDBImageTag)
+	}
+	cmdArgs = append(cmdArgs, args...)
+	c := exec.Command("helm", cmdArgs...)
 	res, err := c.CombinedOutput()
 	if err != nil {
 		t.Fatalf("helm upgrade failed: %s", string(res))

--- a/tests/testdata/snapshots/deployment.yaml/default
+++ b/tests/testdata/snapshots/deployment.yaml/default
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "2.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v3.2.0"
+          image: "surrealdb/surrealdb:v2.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/default
+++ b/tests/testdata/snapshots/deployment.yaml/default
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.7
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/default
+++ b/tests/testdata/snapshots/deployment.yaml/default
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.6
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "2.3.7"
+    app.kubernetes.io/version: "3.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v2.3.7"
+          image: "surrealdb/surrealdb:v3.2.0"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/default
+++ b/tests/testdata/snapshots/deployment.yaml/default
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.5.0
+    helm.sh/chart: surrealdb-0.4.7
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/disable auth using deprecated surrealdb.auth
+++ b/tests/testdata/snapshots/deployment.yaml/disable auth using deprecated surrealdb.auth
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "2.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v3.2.0"
+          image: "surrealdb/surrealdb:v2.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/disable auth using deprecated surrealdb.auth
+++ b/tests/testdata/snapshots/deployment.yaml/disable auth using deprecated surrealdb.auth
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.7
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/disable auth using deprecated surrealdb.auth
+++ b/tests/testdata/snapshots/deployment.yaml/disable auth using deprecated surrealdb.auth
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.6
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "2.3.7"
+    app.kubernetes.io/version: "3.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v2.3.7"
+          image: "surrealdb/surrealdb:v3.2.0"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/disable auth using deprecated surrealdb.auth
+++ b/tests/testdata/snapshots/deployment.yaml/disable auth using deprecated surrealdb.auth
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.5.0
+    helm.sh/chart: surrealdb-0.4.7
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/disable auth using surrealdb.unauhenticated
+++ b/tests/testdata/snapshots/deployment.yaml/disable auth using surrealdb.unauhenticated
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "2.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v3.2.0"
+          image: "surrealdb/surrealdb:v2.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/disable auth using surrealdb.unauhenticated
+++ b/tests/testdata/snapshots/deployment.yaml/disable auth using surrealdb.unauhenticated
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.7
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/disable auth using surrealdb.unauhenticated
+++ b/tests/testdata/snapshots/deployment.yaml/disable auth using surrealdb.unauhenticated
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.6
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "2.3.7"
+    app.kubernetes.io/version: "3.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v2.3.7"
+          image: "surrealdb/surrealdb:v3.2.0"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/disable auth using surrealdb.unauhenticated
+++ b/tests/testdata/snapshots/deployment.yaml/disable auth using surrealdb.unauhenticated
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.5.0
+    helm.sh/chart: surrealdb-0.4.7
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/init and extra containers are set
+++ b/tests/testdata/snapshots/deployment.yaml/init and extra containers are set
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "2.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -38,7 +38,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v3.2.0"
+          image: "surrealdb/surrealdb:v2.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/init and extra containers are set
+++ b/tests/testdata/snapshots/deployment.yaml/init and extra containers are set
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.6
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "2.3.7"
+    app.kubernetes.io/version: "3.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -38,7 +38,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v2.3.7"
+          image: "surrealdb/surrealdb:v3.2.0"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/init and extra containers are set
+++ b/tests/testdata/snapshots/deployment.yaml/init and extra containers are set
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.7
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/init and extra containers are set
+++ b/tests/testdata/snapshots/deployment.yaml/init and extra containers are set
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.5.0
+    helm.sh/chart: surrealdb-0.4.7
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/lifecycle and terminationGracePeriodSeconds are set
+++ b/tests/testdata/snapshots/deployment.yaml/lifecycle and terminationGracePeriodSeconds are set
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "2.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v3.2.0"
+          image: "surrealdb/surrealdb:v2.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/lifecycle and terminationGracePeriodSeconds are set
+++ b/tests/testdata/snapshots/deployment.yaml/lifecycle and terminationGracePeriodSeconds are set
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.7
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/lifecycle and terminationGracePeriodSeconds are set
+++ b/tests/testdata/snapshots/deployment.yaml/lifecycle and terminationGracePeriodSeconds are set
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.6
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "2.3.7"
+    app.kubernetes.io/version: "3.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v2.3.7"
+          image: "surrealdb/surrealdb:v3.2.0"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/lifecycle and terminationGracePeriodSeconds are set
+++ b/tests/testdata/snapshots/deployment.yaml/lifecycle and terminationGracePeriodSeconds are set
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.5.0
+    helm.sh/chart: surrealdb-0.4.7
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are missing in values
+++ b/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are missing in values
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "2.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v3.2.0"
+          image: "surrealdb/surrealdb:v2.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are missing in values
+++ b/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are missing in values
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.7
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are missing in values
+++ b/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are missing in values
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.6
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "2.3.7"
+    app.kubernetes.io/version: "3.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v2.3.7"
+          image: "surrealdb/surrealdb:v3.2.0"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are missing in values
+++ b/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are missing in values
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.5.0
+    helm.sh/chart: surrealdb-0.4.7
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are overridden
+++ b/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are overridden
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "2.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v3.2.0"
+          image: "surrealdb/surrealdb:v2.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are overridden
+++ b/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are overridden
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.7
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are overridden
+++ b/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are overridden
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.6
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "2.3.7"
+    app.kubernetes.io/version: "3.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v2.3.7"
+          image: "surrealdb/surrealdb:v3.2.0"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are overridden
+++ b/tests/testdata/snapshots/deployment.yaml/liveness and readiness probes are overridden
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.5.0
+    helm.sh/chart: surrealdb-0.4.7
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/release deployed using pre v0.3.5 chart with the default surrealdb.auth
+++ b/tests/testdata/snapshots/deployment.yaml/release deployed using pre v0.3.5 chart with the default surrealdb.auth
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "2.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v3.2.0"
+          image: "surrealdb/surrealdb:v2.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/release deployed using pre v0.3.5 chart with the default surrealdb.auth
+++ b/tests/testdata/snapshots/deployment.yaml/release deployed using pre v0.3.5 chart with the default surrealdb.auth
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.7
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/release deployed using pre v0.3.5 chart with the default surrealdb.auth
+++ b/tests/testdata/snapshots/deployment.yaml/release deployed using pre v0.3.5 chart with the default surrealdb.auth
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.6
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "2.3.7"
+    app.kubernetes.io/version: "3.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v2.3.7"
+          image: "surrealdb/surrealdb:v3.2.0"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/release deployed using pre v0.3.5 chart with the default surrealdb.auth
+++ b/tests/testdata/snapshots/deployment.yaml/release deployed using pre v0.3.5 chart with the default surrealdb.auth
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.5.0
+    helm.sh/chart: surrealdb-0.4.7
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/surrealdb.unauthenticated=false has no effect
+++ b/tests/testdata/snapshots/deployment.yaml/surrealdb.unauthenticated=false has no effect
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "2.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v3.2.0"
+          image: "surrealdb/surrealdb:v2.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/surrealdb.unauthenticated=false has no effect
+++ b/tests/testdata/snapshots/deployment.yaml/surrealdb.unauthenticated=false has no effect
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.7
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/surrealdb.unauthenticated=false has no effect
+++ b/tests/testdata/snapshots/deployment.yaml/surrealdb.unauthenticated=false has no effect
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.6
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "2.3.7"
+    app.kubernetes.io/version: "3.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v2.3.7"
+          image: "surrealdb/surrealdb:v3.2.0"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/surrealdb.unauthenticated=false has no effect
+++ b/tests/testdata/snapshots/deployment.yaml/surrealdb.unauthenticated=false has no effect
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.5.0
+    helm.sh/chart: surrealdb-0.4.7
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/update strategy to Recreate
+++ b/tests/testdata/snapshots/deployment.yaml/update strategy to Recreate
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "2.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v3.2.0"
+          image: "surrealdb/surrealdb:v2.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/update strategy to Recreate
+++ b/tests/testdata/snapshots/deployment.yaml/update strategy to Recreate
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.7
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/update strategy to Recreate
+++ b/tests/testdata/snapshots/deployment.yaml/update strategy to Recreate
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.6
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "2.3.7"
+    app.kubernetes.io/version: "3.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v2.3.7"
+          image: "surrealdb/surrealdb:v3.2.0"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/update strategy to Recreate
+++ b/tests/testdata/snapshots/deployment.yaml/update strategy to Recreate
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.5.0
+    helm.sh/chart: surrealdb-0.4.7
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/volumes and volumeMounts are set
+++ b/tests/testdata/snapshots/deployment.yaml/volumes and volumeMounts are set
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "2.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v3.2.0"
+          image: "surrealdb/surrealdb:v2.6.5"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/volumes and volumeMounts are set
+++ b/tests/testdata/snapshots/deployment.yaml/volumes and volumeMounts are set
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.7
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/deployment.yaml/volumes and volumeMounts are set
+++ b/tests/testdata/snapshots/deployment.yaml/volumes and volumeMounts are set
@@ -5,10 +5,10 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.6
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "2.3.7"
+    app.kubernetes.io/version: "3.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -31,7 +31,7 @@ spec:
         - name: surrealdb
           securityContext:
             {}
-          image: "surrealdb/surrealdb:v2.3.7"
+          image: "surrealdb/surrealdb:v3.2.0"
           imagePullPolicy: IfNotPresent
           args:
             - start

--- a/tests/testdata/snapshots/deployment.yaml/volumes and volumeMounts are set
+++ b/tests/testdata/snapshots/deployment.yaml/volumes and volumeMounts are set
@@ -5,7 +5,7 @@ kind: Deployment
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.5.0
+    helm.sh/chart: surrealdb-0.4.7
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/pvc.yaml/persistence enabled with storageClassName and selector
+++ b/tests/testdata/snapshots/pvc.yaml/persistence enabled with storageClassName and selector
@@ -8,7 +8,7 @@ metadata:
     helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "3.2.0"
+    app.kubernetes.io/version: "2.6.5"
     app.kubernetes.io/managed-by: Helm
 spec:
   storageClassName: fast-ssd

--- a/tests/testdata/snapshots/pvc.yaml/persistence enabled with storageClassName and selector
+++ b/tests/testdata/snapshots/pvc.yaml/persistence enabled with storageClassName and selector
@@ -5,10 +5,10 @@ kind: PersistentVolumeClaim
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.6
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
-    app.kubernetes.io/version: "2.3.7"
+    app.kubernetes.io/version: "3.2.0"
     app.kubernetes.io/managed-by: Helm
 spec:
   storageClassName: fast-ssd

--- a/tests/testdata/snapshots/pvc.yaml/persistence enabled with storageClassName and selector
+++ b/tests/testdata/snapshots/pvc.yaml/persistence enabled with storageClassName and selector
@@ -5,7 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.5.0
+    helm.sh/chart: surrealdb-0.4.7
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"

--- a/tests/testdata/snapshots/pvc.yaml/persistence enabled with storageClassName and selector
+++ b/tests/testdata/snapshots/pvc.yaml/persistence enabled with storageClassName and selector
@@ -5,7 +5,7 @@ kind: PersistentVolumeClaim
 metadata:
   name: testrelease-surrealdb
   labels:
-    helm.sh/chart: surrealdb-0.4.7
+    helm.sh/chart: surrealdb-0.5.0
     app.kubernetes.io/name: surrealdb
     app.kubernetes.io/instance: testrelease
     app.kubernetes.io/version: "2.6.5"


### PR DESCRIPTION
The chart works with SurrealDB 3.x, but wasn't proven in CI, so here it is.

I've also added some guidance about pinning image.tag and v2->v3 upgrade path for least surprise.

## Summary
- Bumps the chart default from stale SurrealDB 2.3.7 to supported **2.6.5** (chart **0.5.0**). Minor bump because an empty `image.tag` follows `appVersion`, so upgrades change the deployed image.
- Adds CI/e2e coverage for both `v2.6.5` and `v3.2.0` (including persistence); e2e requires `SURREALDB_IMAGE_TAG`. SurrealDB 3.x remains opt-in via `image.tag` (not the chart default).
- Documents the official [2.x to 3.x migration guide](https://surrealdb.com/docs/build/migrating/from-old-surrealdb-versions/2x-to-3x).
- `make test` runs unit tests then sequential e2e for both tags (`-count=1`).

Closes #32

## Test plan
- [x] `go test ./tests/...` (snapshots for 0.5.0 / 2.6.5)
- [x] `make docs` / SurrealDB versions note in README
- [x] Local e2e / `make test` for v2.6.5 and v3.2.0
- [x] CI: e2e matrix, install-chart with 3.2.0 persistence values, test-success includes e2e