### PR TITLE
Test CI against maintained Kubernetes versions only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,11 +70,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          # from https://hub.docker.com/r/kindest/node/tags
-          - v1.31.12
-          - v1.32.8
-          - v1.33.4
-          - v1.34.0
+          # maintained minors; tags from https://hub.docker.com/r/kindest/node/tags
+          - v1.34.8
+          - v1.35.5
+          - v1.36.1
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -90,7 +89,7 @@ jobs:
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           node_image: kindest/node:${{ matrix.k8s }}
-          version: v0.20.0
+          version: v0.32.0
 
       - name: Validate rendered manifests
         run: make validate-manifests
@@ -147,8 +146,8 @@ jobs:
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
-          node_image: kindest/node:v1.29.2
-          version: v0.20.0
+          node_image: kindest/node:v1.36.1
+          version: v0.32.0
 
       - name: Run e2e test
         # The timeout is explicitly set to clarify that we intend it to be short enough
@@ -171,11 +170,10 @@ jobs:
     strategy:
       matrix:
         k8s:
-          # from https://hub.docker.com/r/kindest/node/tags
-          - v1.31.12
-          - v1.32.8
-          - v1.33.4
-          - v1.34.0
+          # maintained minors; tags from https://hub.docker.com/r/kindest/node/tags
+          - v1.34.8
+          - v1.35.5
+          - v1.36.1
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -186,7 +184,7 @@ jobs:
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           node_image: kindest/node:${{ matrix.k8s }}
-          version: v0.20.0
+          version: v0.32.0
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0


### PR DESCRIPTION
Update the CI kind matrix and e2e cluster to Kubernetes 1.34-1.36, and bump kind so those node images work